### PR TITLE
[EOPS-647] Update EHR file check script to not output an error for every row in a file

### DIFF
--- a/omop_file_validator.py
+++ b/omop_file_validator.py
@@ -419,6 +419,8 @@ def run_checks(file_path, f):
                                                  actual=value,
                                                  expected=meta_column_type)
                                         result['errors'].append(e)
+                                        #only return the first error
+                                        break
 
                     # Check if any nulls present in a required field
                     if meta_column_required and df[submission_column].isnull(

--- a/tests/resources/examples_erroneous/errors/results.csv
+++ b/tests/resources/examples_erroneous/errors/results.csv
@@ -21,6 +21,5 @@
 "observation.csv","Observation","Type mismatch line number 5","observation_id","23.890+11","integer"
 "observation.csv","Observation","Invalid date format. Expecting ""YYYY-MM-DD"": line number 5","observation_date","01-31-1963","date"
 "observation.csv","Observation","Invalid timestamp format. Expecting ""YYYY-MM-DD HH:MM:SS[.SSSSSS]"": line number 1","observation_datetime","1989-10-07 22:13:11.1533266","timestamp"
-"observation.csv","Observation","Invalid timestamp format. Expecting ""YYYY-MM-DD HH:MM:SS[.SSSSSS]"": line number 3","observation_datetime","1987-04-15 06:06:30.6260548","timestamp"
-"observation.csv","Observation","Invalid timestamp format. Expecting ""YYYY-MM-DD HH:MM:SS[.SSSSSS]"": line number 5","observation_datetime","1983-05-13 15:31:52.3905384","timestamp"
 "observation.csv","Observation","Type mismatch line number 3","observation_type_concept_id","unknown","integer"
+"visit_detail.csv","Visit Detail","NULL values are not allowed for column","visit_occurrence_id","",""

--- a/tests/resources/examples_erroneous/errors/results.html
+++ b/tests/resources/examples_erroneous/errors/results.html
@@ -245,26 +245,18 @@ h1 {
     <tr>
       <td>observation.csv</td>
       <td>Observation</td>
-      <td>Invalid timestamp format. Expecting "YYYY-MM-DD HH:MM:SS[.SSSSSS]": line number 3</td>
-      <td>observation_datetime</td>
-      <td>1987-04-15 06:06:30.6260548</td>
-      <td>timestamp</td>
-    </tr>
-    <tr>
-      <td>observation.csv</td>
-      <td>Observation</td>
-      <td>Invalid timestamp format. Expecting "YYYY-MM-DD HH:MM:SS[.SSSSSS]": line number 5</td>
-      <td>observation_datetime</td>
-      <td>1983-05-13 15:31:52.3905384</td>
-      <td>timestamp</td>
-    </tr>
-    <tr>
-      <td>observation.csv</td>
-      <td>Observation</td>
       <td>Type mismatch line number 3</td>
       <td>observation_type_concept_id</td>
       <td>unknown</td>
       <td>integer</td>
+    </tr>
+    <tr>
+      <td>visit_detail.csv</td>
+      <td>Visit Detail</td>
+      <td>NULL values are not allowed for column</td>
+      <td>visit_occurrence_id</td>
+      <td></td>
+      <td></td>
     </tr>
   </tbody>
 </table>

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -119,11 +119,11 @@ class TestReporter(unittest.TestCase):
                                 column_name="observation_type_concept_id",
                                 expected="integer")
 
-        # "observation.csv" has has invalid date formats in rows 4 and 5
+        # "observation.csv" has has invalid date formats in row 5
         self.check_invalid_date(error_map[f_name], column_name='observation_date', linenumber=5)
 
         # "observation.csv" has has invalid timestamp formats in rows 1, 3, and 5
-        self.check_invalid_timestamp(error_map[f_name], column_name='observation_datetime', linenumber=3)
+        self.check_invalid_timestamp(error_map[f_name], column_name='observation_datetime', linenumber=1)
 
         # "measurement.csv" has "person_id" as NULL in row 3 (line number 4) but it is a required value
         f_name = "measurement.csv"


### PR DESCRIPTION
The file check script was searching for and outputting an error for every individual row with a date/timestamp error. This fix only returns the first instance of date/timestamp error to improve efficiency.