### PR TITLE
Add JSON file to define participant_match table.

### DIFF
--- a/resources/omop/participant_match.json
+++ b/resources/omop/participant_match.json
@@ -1,0 +1,12 @@
+[
+    { "name": "person_id",            "mode": "required", "type": "integer", "description": "A unique identifier for each person. The person_id will be the PMID provided from the DRC. PMID starts with a letter 'P' followed by a series of digits. Please strip off the letter 'P' and only put the digits here." },
+    { "name": "first_name",           "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
+    { "name": "last_name",            "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
+    { "name": "dob",                  "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
+    { "name": "sex",                  "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
+    { "name": "address",              "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
+    { "name": "phone_number",         "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
+    { "name": "email",                "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
+    { "name": "algorithm_validation", "mode": "required", "type": "string",  "description": "Algorithm Validation is for the sites' `automated` matching approach: eg, first name, last name, and DOB all matched." },
+    { "name": "manual_validation",    "mode": "required", "type": "string",  "description": "Manual validation additionally tracks whether an individual manually reviewed the EHR-AoU linkage." }
+]

--- a/resources/omop/participant_match.json
+++ b/resources/omop/participant_match.json
@@ -1,12 +1,62 @@
 [
-    { "name": "person_id",            "mode": "required", "type": "integer", "description": "A unique identifier for each person. The person_id will be the PMID provided from the DRC. PMID starts with a letter 'P' followed by a series of digits. Please strip off the letter 'P' and only put the digits here." },
-    { "name": "first_name",           "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
-    { "name": "last_name",            "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
-    { "name": "dob",                  "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
-    { "name": "sex",                  "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
-    { "name": "address",              "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
-    { "name": "phone_number",         "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
-    { "name": "email",                "mode": "required", "type": "string",  "description": "Allowed values are match, no_match, missing, and excluded." },
-    { "name": "algorithm_validation", "mode": "required", "type": "string",  "description": "Algorithm Validation is for the sites' `automated` matching approach: eg, first name, last name, and DOB all matched." },
-    { "name": "manual_validation",    "mode": "required", "type": "string",  "description": "Manual validation additionally tracks whether an individual manually reviewed the EHR-AoU linkage." }
+    {
+        "type": "integer",
+        "name": "person_id",
+        "mode": "required",
+        "description": "A unique identifier for each person."
+    },
+    {
+        "type": "string",
+        "name": "first_name",
+        "mode": "nullable",
+        "description": "Allowed values for this field is match, no_match, missing, and excluded."
+    },
+    {
+        "type": "string",
+        "name": "last_name",
+        "mode": "nullable",
+        "description": "Allowed values for this field is match, no_match, missing, and excluded."
+    },
+    {
+        "type": "string",
+        "name": "dob",
+        "mode": "nullable",
+        "description": "Allowed values for this field is match, no_match, missing, and excluded."
+    },
+    {
+        "type": "string",
+        "name": "sex",
+        "mode": "nullable",
+        "description": "Allowed values for this field is match, no_match, missing, and excluded."
+    },
+    {
+        "type": "string",
+        "name": "address",
+        "mode": "nullable",
+        "description": "Allowed values for this field is match, no_match, missing, and excluded."
+    },
+    {
+        "type": "string",
+        "name": "phone_number",
+        "mode": "nullable",
+        "description": "Allowed values for this field is match, no_match, missing, and excluded."
+    },
+    {
+        "type": "string",
+        "name": "email",
+        "mode": "nullable",
+        "description": "Allowed values for this field is match, no_match, missing, and excluded."
+    },
+    {
+        "type": "string",
+        "name": "algorithm_validation",
+        "mode": "nullable",
+        "description": "Algorithm Validation is for the sites’ “automated” matching approach: eg, first name, last name, and DOB all matched."
+    },
+    {
+        "type": "string",
+        "name": "manual_validation",
+        "mode": "nullable",
+        "description": "Manual validation additionally tracks whether an individual manually reviewed the EHR-AoU linkage. The expectation is that every submitted participant would match either by algorithm or manually."
+    }
 ]


### PR DESCRIPTION
While PR #16 resolved most of the "... is not a OMOP table" errors by adding pii_*.json files, it omitted a definition for participant_match .

This PR adds JSON for participant_match, which should remove the last of the "errors that everyone gets but everyone is supposed to know to ignore".

Based on: https://sites.google.com/view/ehrupload/omop-tables/participant-tables 
and https://aou-ehr-ops.zendesk.com/hc/en-us/articles/1500012461361-Participant-Tables .

If you don't like the formatting (or anything else), just respond to this PR with your specific dissatisfaction, and I will reformat the JSON (or make other needed adjustments) and update the PR.
