### PR TITLE
[EOPS-661] Remove Lowering of CSV Headers

### DIFF
--- a/omop_file_validator.py
+++ b/omop_file_validator.py
@@ -353,8 +353,6 @@ def run_checks(file_path, f):
                          parse_dates=False,
                          infer_datetime_format=False)
 
-        # lowercase field names
-        df = df.rename(columns=str.lower)
 
         # Check each column exists with correct type and required
         for meta_item in cdm_table_columns:


### PR DESCRIPTION
Removed a line lowering csv file header names before checks. Now case sensitive column headers are strictly enforced.