### PR TITLE
[EHR-675] Relax EHR file check script datetime requirements

### DIFF
--- a/omop_file_validator.py
+++ b/omop_file_validator.py
@@ -27,30 +27,17 @@ ERROR_KEYS = ['message', 'column_name', 'actual', 'expected']
 
 VALID_DATE_FORMAT = ['%Y-%m-%d']
 
-VALID_TIMESTAMP_FORMAT = ['%Y-%m-%d %H:%M',
- '%Y-%m-%d %H:%MZ',
- '%Y-%m-%d %H:%M %Z',
- '%Y-%m-%d %H:%M%z',
- '%Y-%m-%d %H:%M:%S',
- '%Y-%m-%d %H:%M:%SZ',
- '%Y-%m-%d %H:%M:%S %Z',
- '%Y-%m-%d %H:%M:%S%z',
- '%Y-%m-%d %H:%M:%S.%f',
- '%Y-%m-%d %H:%M:%S.%fZ',
- '%Y-%m-%d %H:%M:%S.%f %Z',
- '%Y-%m-%d %H:%M:%S.%f%z',
- '%Y-%m-%dT%H:%M',
- '%Y-%m-%dT%H:%MZ',
- '%Y-%m-%dT%H:%M %Z',
- '%Y-%m-%dT%H:%M%z',
- '%Y-%m-%dT%H:%M:%S',
- '%Y-%m-%dT%H:%M:%SZ',
- '%Y-%m-%dT%H:%M:%S %Z',
- '%Y-%m-%dT%H:%M:%S%z',
- '%Y-%m-%dT%H:%M:%S.%f',
- '%Y-%m-%dT%H:%M:%S.%fZ',
- '%Y-%m-%dT%H:%M:%S.%f %Z',
- '%Y-%m-%dT%H:%M:%S.%f%z']
+VALID_TIMESTAMP_FORMAT = [
+    '%Y-%m-%d %H:%M', '%Y-%m-%d %H:%MZ', '%Y-%m-%d %H:%M %Z',
+    '%Y-%m-%d %H:%M%z', '%Y-%m-%d %H:%M:%S', '%Y-%m-%d %H:%M:%SZ',
+    '%Y-%m-%d %H:%M:%S %Z', '%Y-%m-%d %H:%M:%S%z', '%Y-%m-%d %H:%M:%S.%f',
+    '%Y-%m-%d %H:%M:%S.%fZ', '%Y-%m-%d %H:%M:%S.%f %Z',
+    '%Y-%m-%d %H:%M:%S.%f%z', '%Y-%m-%dT%H:%M', '%Y-%m-%dT%H:%MZ',
+    '%Y-%m-%dT%H:%M %Z', '%Y-%m-%dT%H:%M%z', '%Y-%m-%dT%H:%M:%S',
+    '%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S %Z', '%Y-%m-%dT%H:%M:%S%z',
+    '%Y-%m-%dT%H:%M:%S.%f', '%Y-%m-%dT%H:%M:%S.%fZ', '%Y-%m-%dT%H:%M:%S.%f %Z',
+    '%Y-%m-%dT%H:%M:%S.%f%z'
+]
 
 SCIENTIFIC_NOTATION_REGEX = "^(?:-?\d*)\.?\d+[eE][-\+]?\d+$"
 
@@ -140,7 +127,7 @@ def date_format_valid(date_str, fmt='%Y-%m-%d'):
 
     try:
         #Avoids out of range dates, e.g. 2020-02-31
-        datetime.datetime.strptime(date_str, fmt)
+        pd.to_datetime(date_str, format=fmt)  # this will allow >6 microseconds
     except ValueError:
         return False
 
@@ -353,7 +340,6 @@ def run_checks(file_path, f):
                          parse_dates=False,
                          infer_datetime_format=False)
 
-
         # Check each column exists with correct type and required
         for meta_item in cdm_table_columns:
             meta_column_name = meta_item['name']
@@ -404,10 +390,8 @@ def run_checks(file_path, f):
                                 if not any(
                                         list(
                                             map(
-                                                lambda fmt:
-                                                date_format_valid(
-                                                    str(value), fmt),
-                                                fmts))):
+                                                lambda fmt: date_format_valid(
+                                                    str(value), fmt), fmts))):
                                     if not (pd.isnull(value)
                                             and not meta_column_required):
                                         e = dict(message=err_msg +

--- a/tests/resources/examples_erroneous/errors/results.csv
+++ b/tests/resources/examples_erroneous/errors/results.csv
@@ -20,6 +20,6 @@
 "observation.csv","Observation","Scientific notation value '7.47e8' was found on line 2. Scientific notation is not allowed for integer fields.","observation_type_concept_id","",""
 "observation.csv","Observation","Type mismatch line number 5","observation_id","23.890+11","integer"
 "observation.csv","Observation","Invalid date format. Expecting ""YYYY-MM-DD"": line number 5","observation_date","01-31-1963","date"
-"observation.csv","Observation","Invalid timestamp format. Expecting ""YYYY-MM-DD HH:MM:SS[.SSSSSS]"": line number 1","observation_datetime","1989-10-07 22:13:11.1533266","timestamp"
+"observation.csv","Observation","Invalid timestamp format. Expecting ""YYYY-MM-DD HH:MM:SS[.SSSSSS]"": line number 3","observation_datetime","04-15-1987 06:06:30.6260548","timestamp"
 "observation.csv","Observation","Type mismatch line number 3","observation_type_concept_id","unknown","integer"
 "visit_detail.csv","Visit Detail","NULL values are not allowed for column","visit_occurrence_id","",""

--- a/tests/resources/examples_erroneous/errors/results.html
+++ b/tests/resources/examples_erroneous/errors/results.html
@@ -237,9 +237,9 @@ h1 {
     <tr>
       <td>observation.csv</td>
       <td>Observation</td>
-      <td>Invalid timestamp format. Expecting "YYYY-MM-DD HH:MM:SS[.SSSSSS]": line number 1</td>
+      <td>Invalid timestamp format. Expecting "YYYY-MM-DD HH:MM:SS[.SSSSSS]": line number 3</td>
       <td>observation_datetime</td>
-      <td>1989-10-07 22:13:11.1533266</td>
+      <td>04-15-1987 06:06:30.6260548</td>
       <td>timestamp</td>
     </tr>
     <tr>

--- a/tests/resources/examples_erroneous/observation.csv
+++ b/tests/resources/examples_erroneous/observation.csv
@@ -1,6 +1,6 @@
 "observation_id","person_id","observation_concept_id","observation_date","observation_datetime","observation_type_concept_id","value_as_number","value_as_string","value_as_concept_id","qualifier_concept_id","unit_concept_id","provider_id","visit_occurrence_id","visit_detail_id","observation_source_value","observation_source_concept_id","unit_source_value","qualifier_source_value"
 "6","6","6","1996-09-14","1989-10-07 22:13:11.1533266","6","832.66752717675058","GJTXJ2SIOOO92MMRZIG431F8W2AMP8GG8M","6","6","6","6","6","5","Add. Words","5","Internet","Internet"
 "7.23e7","7","7","1990-06-03","1960-01-24 18:00:23","7.47e8","49.08448646268085","20RU9IJZEM71GNQAYFMCE4K1HR5TG781FEJQ8N7LK20MO1UY","7",,"7","7","7","8","Internet","6","Sales","Add. Words"
-"8","8","8","1959-09-12","1987-04-15 06:06:30.6260548","unknown","1253.5394752647446","Y","8","8","8","8","8","2","Sales","7","Sales","Previous Customer"
+"8","8","8","1959-09-12","04-15-1987 06:06:30.6260548","unknown","1253.5394752647446","Y","8","8","8","8","8","2","Sales","7","Sales","Previous Customer"
 "9e7","9","9","1975-9-5","1982-02-26 12:35:59","9","1555.1072552591129","1LASYGPDHCPI7D6M1401B81SC4XCF","9","9","9","9","9","1","Previous Customer","8","Word of mouth","Sales"
 "23.890+11","10","10","01-31-1963","1983-05-13 15:31:52.3905384","10","579.16600097863284","7UIP","10","10","10","10","10",,"Word of mouth","9","Previous Customer","Word of mouth"

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -16,7 +16,6 @@ class TestReporter(unittest.TestCase):
         self.assertIn(message, all_messages)
 
         message_index = all_messages.index(message)
-        
 
         if actual is not None:
             self.assertEqual(errors[message_index]['actual'], actual)
@@ -65,17 +64,18 @@ class TestReporter(unittest.TestCase):
             errors,
             message=
             f'Invalid date format. Expecting "YYYY-MM-DD": line number {linenumber}',
-            column_name=column_name
-        )
+            column_name=column_name)
 
-    def check_invalid_timestamp(self, errors, column_name=None, linenumber=None):
+    def check_invalid_timestamp(self,
+                                errors,
+                                column_name=None,
+                                linenumber=None):
         self.check_error(
             errors,
-            message=f'Invalid timestamp format. Expecting "YYYY-MM-DD HH:MM:SS[.SSSSSS]": line number {linenumber}',
-            column_name=column_name
-        )
+            message=
+            f'Invalid timestamp format. Expecting "YYYY-MM-DD HH:MM:SS[.SSSSSS]": line number {linenumber}',
+            column_name=column_name)
 
-    
     def check_required_value(self, errors, actual=None, column_name=None):
         self.check_error(errors,
                          message=omop_file_validator.MSG_NULL_DISALLOWED,
@@ -120,10 +120,14 @@ class TestReporter(unittest.TestCase):
                                 expected="integer")
 
         # "observation.csv" has has invalid date formats in row 5
-        self.check_invalid_date(error_map[f_name], column_name='observation_date', linenumber=5)
+        self.check_invalid_date(error_map[f_name],
+                                column_name='observation_date',
+                                linenumber=5)
 
         # "observation.csv" has has invalid timestamp formats in rows 1, 3, and 5
-        self.check_invalid_timestamp(error_map[f_name], column_name='observation_datetime', linenumber=1)
+        self.check_invalid_timestamp(error_map[f_name],
+                                     column_name='observation_datetime',
+                                     linenumber=3)
 
         # "measurement.csv" has "person_id" as NULL in row 3 (line number 4) but it is a required value
         f_name = "measurement.csv"
@@ -133,7 +137,8 @@ class TestReporter(unittest.TestCase):
         # "visit_detail.csv" has "visit_occurrence_id" as NULL in row 1 but it is a required value
         f_name = "visit_detail.csv"
         self.assertIn(f_name, error_map)
-        self.check_required_value(error_map[f_name], column_name='visit_occurrence_id')
+        self.check_required_value(error_map[f_name],
+                                  column_name='visit_occurrence_id')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changed script to use pandas `to_datetime` function to allow >6 digit microsecond datetimes to pass checks.